### PR TITLE
tests : failing tests - 1) non-standard character not parsed, 2) TODO in title triggers a syntax error, 3) a title with just a tag triggers an error

### DIFF
--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -15,9 +15,9 @@ EXAMPLES = (
 ** Evaluation
 """,
     """\
-* Parse weird characters
+* Parse weird characters
 
-There is a weird character between these two   words.
+There   is   a weird character between 3 of these   words.
 """,
 )
 

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -19,6 +19,11 @@ EXAMPLES = (
 
 There is a weird {} character {} between 2 of these words.
 """.format(chr(160), chr(8239), chr(160)),
+"""\
+* A normal title
+* TODO A title with the word TODO in the title which triggers a syntax error
+* TODO Another normal title.
+""",
 )
 
 

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -17,8 +17,8 @@ EXAMPLES = (
     """\
 * Parse weird characters
 
-There   is   a weird character between 3 of these   words.
-""",
+There   is   a weird {} character {} between 5 of these   words.
+""".format(chr(8239), chr(160)),
 )
 
 

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -7,22 +7,31 @@ from orgmunge import Org
 import pytest
 
 
-EXAMPLE_1 = """\
+EXAMPLES = (
+    """\
 * Calculation TODO
 ** Input
 3+4+5+6
 ** Evaluation
-"""
+""",
+    """\
+* Parse weird characters
+
+There is a weird character between these two   words.
+""",
+)
 
 
-@pytest.mark.parametrize("text", (EXAMPLE_1,))
+@pytest.mark.parametrize("text", EXAMPLES)
 def test_roundtrip(text):
-    fake_todos = {'todo_states': {'fake_todo': 'TDO'},
-                  'done_states': {'fake_done': 'DNE'},}
-    parsed = Org(EXAMPLE_1, from_file=False, todos=fake_todos)
+    fake_todos = {
+        "todo_states": {"fake_todo": "TDO"},
+        "done_states": {"fake_done": "DNE"},
+    }
+    parsed = Org(text, from_file=False, todos=fake_todos)
 
     # Doesn't produce errors when roundtripped
     Org(str(parsed), from_file=False, todos=fake_todos)
 
     # Produces identical output roundtripped
-    assert str(parsed) == EXAMPLE_1
+    assert str(parsed) == text

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -9,7 +9,7 @@ import pytest
 
 EXAMPLES = (
     """\
-* Calculation TODO
+* TODO Calculation
 ** Input
 3+4+5+6
 ** Evaluation
@@ -21,22 +21,26 @@ There is a weird {} character {} between 2 of these words.
 """.format(chr(160), chr(8239), chr(160)),
 """\
 * A normal title
-* TODO A title with the word TODO in the title which triggers a syntax error
+* TODO A title with the -- word TODO in the title which triggers a syntax error
 * TODO Another normal title.
 """,
+"""\
+* :atitlewithjustatag:
+"""
 )
 
 
 @pytest.mark.parametrize("text", EXAMPLES)
 def test_roundtrip(text):
-    fake_todos = {
-        "todo_states": {"fake_todo": "TDO"},
-        "done_states": {"fake_done": "DNE"},
+    todo_and_done_states = {
+        "todo_states": {"todo": "TODO"},
+        "done_states": {"done": "DONE"},
     }
-    parsed = Org(text, from_file=False, todos=fake_todos)
+    # Shouldn't produce errors when parsed
+    parsed = Org(text, from_file=False, todos=todo_and_done_states)
 
-    # Doesn't produce errors when roundtripped
-    Org(str(parsed), from_file=False, todos=fake_todos)
+    # Shouldn't produce errors when roundtripped
+    Org(str(parsed), from_file=False, todos=todo_and_done_states)
 
-    # Produces identical output roundtripped
+    # Should produce identical output roundtripped
     assert str(parsed) == text

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -15,10 +15,10 @@ EXAMPLES = (
 ** Evaluation
 """,
     """\
-* Parse weird characters
+* Parse{}weird characters
 
-There   is   a weird {} character {} between 5 of these   words.
-""".format(chr(8239), chr(160)),
+There is a weird {} character {} between 2 of these words.
+""".format(chr(160), chr(8239), chr(160)),
 )
 
 


### PR DESCRIPTION
I ran into these bugs when I was parsing some of my own org files.

1) Non-standard characters. They mostly seemed to be triggered by text that I had copied from either a slack message or an email into my org mode files.

2) The second test is about TODO appearing in the title. This test passes for some reason, but it definitely triggered a syntax error when I tried to parse it. I am not sure why this is.

3) The third is a title with only a tag.

I'm following the pattern I set up before - testing that a string gets roundtripped properly.

This PR doesn't contain the fix, I'm afraid, but I figured you'd probably want to see the bugs.
