### PR TITLE
refactor: update _todo_states and _done_states to use set

### DIFF
--- a/src/orgmunge/classes.py
+++ b/src/orgmunge/classes.py
@@ -146,8 +146,8 @@ class Headline:
         self.title = title
         self._cookie = cookie if cookie is None else Cookie(cookie)
         self.tags = tags
-        self._todo_states = list(todos['todo_states'].values())
-        self._done_states = list(todos['done_states'].values())
+        self._todo_states = set(todos['todo_states'].values())
+        self._done_states = set(todos['done_states'].values())
         self._todo_keywords = {**todos['todo_states'], **todos['done_states']}
     @property
     def done(self):


### PR DESCRIPTION
While reviewing the code, I noticed that the `_todo_states` and `_done_states` lists could be better represented as `set`, since they're only used in membership checks (in) in the functions `todo` and `_is_done`. This change improves readability and makes the code more consistent with its actual usage.

Additionally, using `set` ensures O(1) lookups instead of O(n), even though the number of elements is typically small in practice.